### PR TITLE
Fixed controllers not being selected

### DIFF
--- a/src/util/water.ts
+++ b/src/util/water.ts
@@ -168,11 +168,11 @@ export class Water extends Path {
     // Add water and the control circles to the canvas
     // This line is used to put the water in the back - used to make products always clickable
     this.canvas.insertAt(0, this); 
+    this.canvas.add(this.infoLine);
+    this.canvas.add(this.infoText);
     this.canvas.add(this.endController);
     this.canvas.add(this.startController);
     this.canvas.add(this.midController);
-    this.canvas.add(this.infoLine);
-    this.canvas.add(this.infoText);
 
     // Bind the event handlers to the control circles
     this.endController.on({'moving': (e) => {this.onControlCircleMoving(e)},
@@ -241,7 +241,9 @@ export class Water extends Path {
     const centerX = this.getCenterPoint().x,
           centerY = this.getCenterPoint().y;
     let angle = Math.atan2(y - centerY, x - centerX) * (180 / Math.PI);
-    angle = angle >= 0 ? angle : 360 + angle; // Normalize angle
+
+    // Normalize angle
+    angle = angle >= 0 ? angle : 360 + angle;
 
     // Check what controller is being used based on the controllerType
     // and make sure it's within the specifications


### PR DESCRIPTION
Bug Fix
-
- Middle controller would not be selected when clicking inside the water object
  - When clicking inside the water object it would click the radius line instead of the controller
- A product object's controllers were not selectable when inside other product's water object

Changing when the information line and text was added on canvas fixed the issue

Set Up
-
- Clone repo
- In your command line:
  - run npm install to install necessary packages
  - run npm run dev to run the project in your web browser

On your browser, go to localhost:5173 and you should see a page with a black line on the top left and text reading "5 feet" right under it.

Testing
-
- When creating two products, both of their water controls should be controllable, even if their water objects overlap.
- Middle controller is moveable regardless of where Product is placed on the canvas (unless it's out of the canvas bounds)