### PR TITLE
Feature/pro fixed nozzles

### DIFF
--- a/src/components/TestingBoard.vue
+++ b/src/components/TestingBoard.vue
@@ -32,11 +32,12 @@
   let waterScale = 20;
   let products = 0;
 
-  const pressure = ref('45');
-  const product = ref('461006');
+  const pressure = ref('30');
+  const product = ref('884');
   const options = ref([
     { text: 'PGP Ultra', value: '862' },
-    { text: 'MP Rotator', value: '461006' }
+    { text: 'MP Rotator', value: '461006'},
+    { text: 'Pro Adjustable Nozzles', value:'884'}
   ]);
   let newNozzles = [];
   let nozzle = ref(null);

--- a/src/util/data.json
+++ b/src/util/data.json
@@ -2324,5 +2324,494 @@
         }
       }
     }
+  },
+  "884": {
+    "name": "Pro Adjustable Nozzles",
+    "fixedArc": false,
+    "minArc": 0,
+    "maxArc": 360,
+    "minRadius": 4,
+    "maxRadius": 17,
+    "recPressure": "30PSI",
+    "omittedAngles": [],
+    "autoSelect": false,
+    "nozzles": {
+      "4A": {
+        "minRadius": 4,
+        "maxRadius": 4,
+        "minArc": 0,
+        "maxArc": 360,
+        "arcSettings": {"45": 45, "90": 90, "120": 120, "180": 180, "240": 240, "270": 270, "360": 360},
+        "model": {
+          "4A": {
+            "minRadius": 3,
+            "maxRadius": 4,
+            "minArc": 0,
+            "maxArc": 360,
+            "arcSettings": {"45": 45, "90": 90, "120": 120, "180": 180, "240": 240, "270": 270, "360": 360},
+            "color": "#007562",
+            "angles": {
+              "45": {
+                "20PSI": {"radius": 3, "gpm": 0.10, "precip_sq": 7.29, "precip_tri": 8.42 },
+                "25PSI": {"radius": 3, "gpm": 0.11, "precip_sq": 7.12, "precip_tri": 8.22 },
+                "30PSI": {"radius": 4, "gpm": 0.13, "precip_sq": 6.26, "precip_tri": 7.22 },
+                "35PSI": {"radius": 4, "gpm": 0.14, "precip_sq": 6.11, "precip_tri": 7.06 },
+                "40PSI": {"radius": 4, "gpm": 0.16, "precip_sq": 6.36, "precip_tri": 7.35 }
+              },
+              "90": {
+                "20PSI": {"radius": 3, "gpm": 0.19, "precip_sq": 6.93, "precip_tri": 8.00},
+                "25PSI": {"radius": 3, "gpm": 0.20, "precip_sq": 6.47, "precip_tri": 7.47},
+                "30PSI": {"radius": 4, "gpm": 0.22, "precip_sq": 5.29, "precip_tri": 6.11},
+                "35PSI": {"radius": 4, "gpm": 0.24, "precip_sq": 5.24, "precip_tri": 6.05},
+                "40PSI": {"radius": 4, "gpm": 0.25, "precip_sq": 4.97, "precip_tri": 5.74}
+              },
+              "120": {
+                "20PSI": {"radius": 3, "gpm": 0.28, "precip_sq": 7.65, "precip_tri": 8.84},
+                "25PSI": {"radius": 3, "gpm": 0.30, "precip_sq": 7.28, "precip_tri": 8.40},
+                "30PSI": {"radius": 4, "gpm": 0.34, "precip_sq": 6.14, "precip_tri": 7.09},
+                "35PSI": {"radius": 4, "gpm": 0.36, "precip_sq": 5.81, "precip_tri": 6.71},
+                "40PSI": {"radius": 4, "gpm": 0.37, "precip_sq": 5.52, "precip_tri": 6.37}
+              },
+              "180": {
+                "20PSI": {"radius": 3, "gpm": 0.34, "precip_sq": 6.20, "precip_tri": 7.16},
+                "25PSI": {"radius": 3, "gpm": 0.38, "precip_sq": 6.15, "precip_tri": 7.10},
+                "30PSI": {"radius": 4, "gpm": 0.45, "precip_sq": 5.41, "precip_tri": 6.25},
+                "35PSI": {"radius": 4, "gpm": 0.46, "precip_sq": 5.02, "precip_tri": 5.80},
+                "40PSI": {"radius": 4, "gpm": 0.48, "precip_sq": 4.77, "precip_tri": 5.51}
+              },
+              "240": {
+                "20PSI": {"radius": 3, "gpm": 0.58, "precip_sq": 7.93, "precip_tri": 9.15},
+                "25PSI": {"radius": 3, "gpm": 0.62, "precip_sq": 7.52, "precip_tri": 8.68},
+                "30PSI": {"radius": 4, "gpm": 0.68, "precip_sq": 6.14, "precip_tri": 7.09},
+                "35PSI": {"radius": 4, "gpm": 0.74, "precip_sq": 6.06, "precip_tri": 6.99},
+                "40PSI": {"radius": 4, "gpm": 0.80, "precip_sq": 5.97, "precip_tri": 6.89}
+              },
+              "270": {
+                "20PSI": {"radius": 3, "gpm": 0.62, "precip_sq": 7.53, "precip_tri": 8.70},
+                "25PSI": {"radius": 3, "gpm": 0.66, "precip_sq": 7.12, "precip_tri": 8.22},
+                "30PSI": {"radius": 4, "gpm": 0.73, "precip_sq": 5.86, "precip_tri": 6.76},
+                "35PSI": {"radius": 4, "gpm": 0.78, "precip_sq": 5.67, "precip_tri": 6.55},
+                "40PSI": {"radius": 4, "gpm": 0.84, "precip_sq": 5.57, "precip_tri": 6.43}
+              },
+              "360": {
+                "20PSI": {"radius": 3, "gpm": 0.66, "precip_sq": 6.01, "precip_tri": 6.94},
+                "25PSI": {"radius": 3, "gpm": 0.72, "precip_sq": 5.82, "precip_tri": 6.72},
+                "30PSI": {"radius": 4, "gpm": 0.80, "precip_sq": 4.81, "precip_tri": 5.56},
+                "35PSI": {"radius": 4, "gpm": 0.86, "precip_sq": 4.69, "precip_tri": 5.42},
+                "40PSI": {"radius": 4, "gpm": 0.90, "precip_sq": 4.47, "precip_tri": 5.17}
+              }
+            }
+          }
+        }
+      },
+      "6A": {
+        "minRadius": 5,
+        "maxRadius": 6,
+        "minArc": 0,
+        "maxArc": 360,
+        "arcSettings": {"45": 45, "90": 90, "120": 120, "180": 180, "240": 240, "270": 270, "360": 360},
+        "model": {
+          "6A": {
+            "minRadius": 5,
+            "maxRadius": 6,
+            "minArc": 0,
+            "maxArc": 360,
+            "arcSettings": {"45": 45, "90": 90, "120": 120, "180": 180, "240": 240, "270": 270, "360": 360},
+            "color": "#68aee0",
+            "angles": {
+              "45": {
+                "20PSI": {"radius": 5, "gpm": 0.15, "precip_sq": 4.19, "precip_tri": 4.84},
+                "25PSI": {"radius": 5, "gpm": 0.17, "precip_sq": 4.36, "precip_tri": 5.03},
+                "30PSI": {"radius": 6, "gpm": 0.18, "precip_sq": 3.85, "precip_tri": 4.45},
+                "35PSI": {"radius": 6, "gpm": 0.18, "precip_sq": 3.55, "precip_tri": 4.10},
+                "40PSI": {"radius": 6, "gpm": 0.19, "precip_sq": 3.57, "precip_tri": 4.12}
+              },
+              "90": {
+                "20PSI": {"radius": 5, "gpm": 0.30, "precip_sq": 4.19, "precip_tri": 4.84},
+                "25PSI": {"radius": 5, "gpm": 0.34, "precip_sq": 4.49, "precip_tri": 5.18},
+                "30PSI": {"radius": 6, "gpm": 0.37, "precip_sq": 3.96, "precip_tri": 4.57},
+                "35PSI": {"radius": 6, "gpm": 0.38, "precip_sq": 3.75, "precip_tri": 4.32},
+                "40PSI": {"radius": 6, "gpm": 0.40, "precip_sq": 3.76, "precip_tri": 4.34}
+              },
+              "120": {
+                "20PSI": {"radius": 5, "gpm": 0.37, "precip_sq": 3.88, "precip_tri": 4.48},
+                "25PSI": {"radius": 5, "gpm": 0.38, "precip_sq": 3.76, "precip_tri": 4.35},
+                "30PSI": {"radius": 6, "gpm": 0.44, "precip_sq": 3.53, "precip_tri": 4.08},
+                "35PSI": {"radius": 6, "gpm": 0.46, "precip_sq": 3.40, "precip_tri": 3.93},
+                "40PSI": {"radius": 6, "gpm": 0.48, "precip_sq": 3.38, "precip_tri": 3.91}
+              },
+              "180": {
+                "20PSI": {"radius": 5, "gpm": 0.50, "precip_sq": 3.49, "precip_tri": 4.03},
+                "25PSI": {"radius": 5, "gpm": 0.54, "precip_sq": 3.56, "precip_tri": 4.12},
+                "30PSI": {"radius": 6, "gpm": 0.60, "precip_sq": 3.21, "precip_tri": 3.70},
+                "35PSI": {"radius": 6, "gpm": 0.64, "precip_sq": 3.15, "precip_tri": 3.64},
+                "40PSI": {"radius": 6, "gpm": 0.68, "precip_sq": 3.20, "precip_tri": 3.69}
+              },
+              "240": {
+                "20PSI": {"radius": 5, "gpm": 0.73, "precip_sq": 3.82, "precip_tri": 4.42},
+                "25PSI": {"radius": 5, "gpm": 0.78, "precip_sq": 3.86, "precip_tri": 4.46},
+                "30PSI": {"radius": 6, "gpm": 0.88, "precip_sq": 3.53, "precip_tri": 4.08},
+                "35PSI": {"radius": 6, "gpm": 0.92, "precip_sq": 3.40, "precip_tri": 3.93},
+                "40PSI": {"radius": 6, "gpm": 1.02, "precip_sq": 3.60, "precip_tri": 4.15}
+              },
+              "270": {
+                "20PSI": {"radius": 5, "gpm": 0.88, "precip_sq": 4.10, "precip_tri": 4.73},
+                "25PSI": {"radius": 5, "gpm": 0.98, "precip_sq": 4.31, "precip_tri": 4.98},
+                "30PSI": {"radius": 6, "gpm": 1.10, "precip_sq": 3.92, "precip_tri": 4.53},
+                "35PSI": {"radius": 6, "gpm": 1.15, "precip_sq": 3.78, "precip_tri": 4.36},
+                "40PSI": {"radius": 6, "gpm": 1.20, "precip_sq": 3.76, "precip_tri": 4.34}
+              },
+              "360": {
+                "20PSI": {"radius": 5, "gpm": 1.05, "precip_sq": 3.67, "precip_tri": 4.23},
+                "25PSI": {"radius": 5, "gpm": 1.10, "precip_sq": 3.63, "precip_tri": 4.19},
+                "30PSI": {"radius": 6, "gpm": 1.26, "precip_sq": 3.37, "precip_tri": 3.89},
+                "35PSI": {"radius": 6, "gpm": 1.30, "precip_sq": 3.20, "precip_tri": 3.70},
+                "40PSI": {"radius": 6, "gpm": 1.40, "precip_sq": 3.29, "precip_tri": 3.80}
+              }
+            }
+          }
+        }
+      },
+      "8A": {
+        "minRadius": 7,
+        "maxRadius": 9,
+        "minArc": 0,
+        "maxArc": 360,
+        "arcSettings": {"45": 45, "90": 90, "120": 120, "180": 180, "240": 240, "270": 270, "360": 360},
+        "model": {
+          "8A": {
+            "minRadius": 7,
+            "maxRadius": 9,
+            "minArc": 0,
+            "maxArc": 360,
+            "arcSettings": {"45": 45, "90": 90, "120": 120, "180": 180, "240": 240, "270": 270, "360": 360},
+            "color": "#6b4226",
+            "angles": {
+              "45": {
+                "20PSI": {"radius": 7, "gpm": 0.18, "precip_sq": 2.83, "precip_tri": 3.27},
+                "25PSI": {"radius": 8, "gpm": 0.20, "precip_sq": 2.74, "precip_tri": 3.16},
+                "30PSI": {"radius": 8, "gpm": 0.22, "precip_sq": 2.65, "precip_tri": 3.06},
+                "35PSI": {"radius": 9, "gpm": 0.24, "precip_sq": 2.50, "precip_tri": 2.89},
+                "40PSI": {"radius": 9, "gpm": 0.25, "precip_sq": 2.38, "precip_tri": 2.74}
+              },
+              "90": {
+                "20PSI": {"radius": 7, "gpm": 0.36, "precip_sq": 2.83, "precip_tri": 3.27},
+                "25PSI": {"radius": 8, "gpm": 0.40, "precip_sq": 2.74, "precip_tri": 3.16},
+                "30PSI": {"radius": 8, "gpm": 0.44, "precip_sq": 2.65, "precip_tri": 3.06},
+                "35PSI": {"radius": 9, "gpm": 0.47, "precip_sq": 2.50, "precip_tri": 2.89},
+                "40PSI": {"radius": 9, "gpm": 0.50, "precip_sq": 2.38, "precip_tri": 2.74}
+              },
+              "120": {
+                "20PSI": {"radius": 7, "gpm": 0.48, "precip_sq": 2.83, "precip_tri": 3.27},
+                "25PSI": {"radius": 8, "gpm": 0.53, "precip_sq": 2.74, "precip_tri": 3.16},
+                "30PSI": {"radius": 8, "gpm": 0.59, "precip_sq": 2.65, "precip_tri": 3.06},
+                "35PSI": {"radius": 9, "gpm": 0.63, "precip_sq": 2.50, "precip_tri": 2.89},
+                "40PSI": {"radius": 9, "gpm": 0.67, "precip_sq": 2.38, "precip_tri": 2.74}
+              },
+              "180": {
+                "20PSI": {"radius": 7, "gpm": 0.72, "precip_sq": 2.83, "precip_tri": 3.27},
+                "25PSI": {"radius": 8, "gpm": 0.80, "precip_sq": 2.74, "precip_tri": 3.16},
+                "30PSI": {"radius": 8, "gpm": 0.88, "precip_sq": 2.65, "precip_tri": 3.06},
+                "35PSI": {"radius": 9, "gpm": 0.94, "precip_sq": 2.50, "precip_tri": 2.89},
+                "40PSI": {"radius": 9, "gpm": 1.00, "precip_sq": 2.38, "precip_tri": 2.74}
+              },
+              "240": {
+                "20PSI": {"radius": 7, "gpm": 0.96, "precip_sq": 2.83, "precip_tri": 3.27},
+                "25PSI": {"radius": 8, "gpm": 1.07, "precip_sq": 2.74, "precip_tri": 3.16},
+                "30PSI": {"radius": 8, "gpm": 1.17, "precip_sq": 2.65, "precip_tri": 3.06},
+                "35PSI": {"radius": 9, "gpm": 1.25, "precip_sq": 2.50, "precip_tri": 2.89},
+                "40PSI": {"radius": 9, "gpm": 1.33, "precip_sq": 2.38, "precip_tri": 2.74}
+              },
+              "270": {
+                "20PSI": {"radius": 7, "gpm": 1.08, "precip_sq": 2.83, "precip_tri": 3.27},
+                "25PSI": {"radius": 8, "gpm": 1.20, "precip_sq": 2.74, "precip_tri": 3.16},
+                "30PSI": {"radius": 8, "gpm": 1.32, "precip_sq": 2.65, "precip_tri": 3.06},
+                "35PSI": {"radius": 9, "gpm": 1.41, "precip_sq": 2.50, "precip_tri": 2.89},
+                "40PSI": {"radius": 9, "gpm": 1.50, "precip_sq": 2.38, "precip_tri": 2.74}
+              },
+              "360": {
+                "20PSI": {"radius": 7, "gpm": 1.44, "precip_sq": 2.83, "precip_tri": 3.27},
+                "25PSI": {"radius": 8, "gpm": 1.60, "precip_sq": 2.74, "precip_tri": 3.16},
+                "30PSI": {"radius": 8, "gpm": 1.76, "precip_sq": 2.65, "precip_tri": 3.06},
+                "35PSI": {"radius": 9, "gpm": 1.88, "precip_sq": 2.50, "precip_tri": 2.89},
+                "40PSI": {"radius": 9, "gpm": 2.00, "precip_sq": 2.38, "precip_tri": 2.74}
+              }
+            }
+          }
+        }
+      },
+      "10A": {
+        "minRadius": 9,
+        "maxRadius": 11,
+        "minArc": 0,
+        "maxArc": 360,
+        "arcSettings": {"45": 45, "90": 90, "120": 120, "180": 180, "240": 240, "270": 270, "360": 360},
+        "model": {
+          "10A": {
+            "minRadius": 9,
+            "maxRadius": 11,
+            "minArc": 0,
+            "maxArc": 360,
+            "arcSettings": {"45": 45, "90": 90, "120": 120, "180": 180, "240": 240, "270": 270, "360": 360},
+            "color": "#FF0000",
+            "angles": {
+              "45": {
+                "20PSI": {"radius": 9, "gpm": 0.20, "precip_sq": 1.90, "precip_tri": 2.20},
+                "25PSI": {"radius": 10, "gpm": 0.23, "precip_sq": 1.92, "precip_tri": 2.22},
+                "30PSI": {"radius": 10, "gpm": 0.25, "precip_sq": 1.93, "precip_tri": 2.22},
+                "35PSI": {"radius": 11, "gpm": 0.28, "precip_sq": 1.92, "precip_tri": 2.22},
+                "40PSI": {"radius": 11, "gpm": 0.30, "precip_sq": 1.88, "precip_tri": 2.17}
+              },
+              "90": {
+                "20PSI": {"radius": 9, "gpm": 0.40, "precip_sq": 1.90, "precip_tri": 2.20},
+                "25PSI": {"radius": 10, "gpm": 0.45, "precip_sq": 1.92, "precip_tri": 2.22},
+                "30PSI": {"radius": 10, "gpm": 0.50, "precip_sq": 1.93, "precip_tri": 2.22},
+                "35PSI": {"radius": 11, "gpm": 0.55, "precip_sq": 1.92, "precip_tri": 2.22},
+                "40PSI": {"radius": 11, "gpm": 0.59, "precip_sq": 1.88, "precip_tri": 2.17}
+              },
+              "120": {
+                "20PSI": {"radius": 9, "gpm": 0.53, "precip_sq": 1.90, "precip_tri": 2.20},
+                "25PSI": {"radius": 10, "gpm": 0.60, "precip_sq": 1.92, "precip_tri": 2.22},
+                "30PSI": {"radius": 10, "gpm": 0.67, "precip_sq": 1.93, "precip_tri": 2.22},
+                "35PSI": {"radius": 11, "gpm": 0.73, "precip_sq": 1.92, "precip_tri": 2.22},
+                "40PSI": {"radius": 11, "gpm": 0.79, "precip_sq": 1.88, "precip_tri": 2.17}
+              },
+              "180": {
+                "20PSI": {"radius": 9, "gpm": 0.80, "precip_sq": 1.90, "precip_tri": 2.20},
+                "25PSI": {"radius": 10, "gpm": 0.90, "precip_sq": 1.92, "precip_tri": 2.22},
+                "30PSI": {"radius": 10, "gpm": 1.00, "precip_sq": 1.93, "precip_tri": 2.22},
+                "35PSI": {"radius": 11, "gpm": 1.10, "precip_sq": 1.92, "precip_tri": 2.22},
+                "40PSI": {"radius": 11, "gpm": 1.18, "precip_sq": 1.88, "precip_tri": 2.17}
+              },
+              "240": {
+                "20PSI": {"radius": 9, "gpm": 1.07, "precip_sq": 1.90, "precip_tri": 2.20},
+                "25PSI": {"radius": 10, "gpm": 1.20, "precip_sq": 1.92, "precip_tri": 2.22},
+                "30PSI": {"radius": 10, "gpm": 1.33, "precip_sq": 1.93, "precip_tri": 2.22},
+                "35PSI": {"radius": 11, "gpm": 1.47, "precip_sq": 1.92, "precip_tri": 2.22},
+                "40PSI": {"radius": 11, "gpm": 1.57, "precip_sq": 1.88, "precip_tri": 2.17}
+              },
+              "270": {
+                "20PSI": {"radius": 9, "gpm": 1.20, "precip_sq": 1.90, "precip_tri": 2.20},
+                "25PSI": {"radius": 10, "gpm": 1.35, "precip_sq": 1.92, "precip_tri": 2.22},
+                "30PSI": {"radius": 10, "gpm": 1.50, "precip_sq": 1.93, "precip_tri": 2.22},
+                "35PSI": {"radius": 11, "gpm": 1.65, "precip_sq": 1.92, "precip_tri": 2.22},
+                "40PSI": {"radius": 11, "gpm": 1.77, "precip_sq": 1.88, "precip_tri": 2.17}
+              },
+              "360": {
+                "20PSI": {"radius": 9, "gpm": 1.60, "precip_sq": 1.90, "precip_tri": 2.20},
+                "25PSI": {"radius": 10, "gpm": 1.80, "precip_sq": 1.92, "precip_tri": 2.22},
+                "30PSI": {"radius": 10, "gpm": 2.00, "precip_sq": 1.93, "precip_tri": 2.22},
+                "35PSI": {"radius": 11, "gpm": 2.20, "precip_sq": 1.92, "precip_tri": 2.22},
+                "40PSI": {"radius": 11, "gpm": 2.36, "precip_sq": 1.88, "precip_tri": 2.17}
+              }
+            }
+          }
+        }
+      },
+      "12A": {
+        "minRadius": 9,
+        "maxRadius": 11,
+        "minArc": 0,
+        "maxArc": 360,
+        "arcSettings": {"45": 45, "90": 90, "120": 120, "180": 180, "240": 240, "270": 270, "360": 360},
+        "model": {
+          "12A": {
+            "minRadius": 9,
+            "maxRadius": 11,
+            "minArc": 0,
+            "maxArc": 360,
+            "arcSettings": {"45": 45, "90": 90, "120": 120, "180": 180, "240": 240, "270": 270, "360": 360},
+            "color": "#007562",
+            "angles": {
+              "45": {
+                "20PSI": {"radius": 11, "gpm": 0.25, "precip_sq": 1.59, "precip_tri": 1.84},
+                "25PSI": {"radius": 12, "gpm": 0.28, "precip_sq": 1.60, "precip_tri": 1.85},
+                "30PSI": {"radius": 12, "gpm": 0.32, "precip_sq": 1.68, "precip_tri": 1.95},
+                "35PSI": {"radius": 13, "gpm": 0.37, "precip_sq": 1.80, "precip_tri": 2.08},
+                "40PSI": {"radius": 13, "gpm": 0.42, "precip_sq": 1.91, "precip_tri": 2.21}
+              },
+              "90": {
+                "20PSI": {"radius": 11, "gpm": 0.50, "precip_sq": 1.59, "precip_tri": 1.84},
+                "25PSI": {"radius": 12, "gpm": 0.55, "precip_sq": 1.60, "precip_tri": 1.85},
+                "30PSI": {"radius": 12, "gpm": 0.63, "precip_sq": 1.68, "precip_tri": 1.95},
+                "35PSI": {"radius": 13, "gpm": 0.73, "precip_sq": 1.80, "precip_tri": 2.08},
+                "40PSI": {"radius": 13, "gpm": 0.84, "precip_sq": 1.91, "precip_tri": 2.21}
+              },
+              "120": {
+                "20PSI": {"radius": 11, "gpm": 0.67, "precip_sq": 1.59, "precip_tri": 1.84},
+                "25PSI": {"radius": 12, "gpm": 0.73, "precip_sq": 1.60, "precip_tri": 1.85},
+                "30PSI": {"radius": 12, "gpm": 0.84, "precip_sq": 1.68, "precip_tri": 1.95},
+                "35PSI": {"radius": 13, "gpm": 0.97, "precip_sq": 1.80, "precip_tri": 2.08},
+                "40PSI": {"radius": 13, "gpm": 1.12, "precip_sq": 1.91, "precip_tri": 2.21}
+              },
+              "180": {
+                "20PSI": {"radius": 11, "gpm": 1.00, "precip_sq": 1.59, "precip_tri": 1.84},
+                "25PSI": {"radius": 12, "gpm": 1.10, "precip_sq": 1.60, "precip_tri": 1.85},
+                "30PSI": {"radius": 12, "gpm": 1.26, "precip_sq": 1.68, "precip_tri": 1.95},
+                "35PSI": {"radius": 13, "gpm": 1.46, "precip_sq": 1.80, "precip_tri": 2.08},
+                "40PSI": {"radius": 13, "gpm": 1.68, "precip_sq": 1.91, "precip_tri": 2.21}
+              },
+              "240": {
+                "20PSI": {"radius": 11, "gpm": 1.33, "precip_sq": 1.59, "precip_tri": 1.84},
+                "25PSI": {"radius": 12, "gpm": 1.47, "precip_sq": 1.60, "precip_tri": 1.85},
+                "30PSI": {"radius": 12, "gpm": 1.68, "precip_sq": 1.68, "precip_tri": 1.95},
+                "35PSI": {"radius": 13, "gpm": 1.95, "precip_sq": 1.80, "precip_tri": 2.08},
+                "40PSI": {"radius": 13, "gpm": 2.24, "precip_sq": 1.91, "precip_tri": 2.21}
+              },
+              "270": {
+                "20PSI": {"radius": 11, "gpm": 1.50, "precip_sq": 1.59, "precip_tri": 1.84},
+                "25PSI": {"radius": 12, "gpm": 1.65, "precip_sq": 1.60, "precip_tri": 1.85},
+                "30PSI": {"radius": 12, "gpm": 1.89, "precip_sq": 1.68, "precip_tri": 1.95},
+                "35PSI": {"radius": 13, "gpm": 2.19, "precip_sq": 1.80, "precip_tri": 2.08},
+                "40PSI": {"radius": 13, "gpm": 2.52, "precip_sq": 1.91, "precip_tri": 2.21}
+              },
+              "360": {
+                "20PSI": {"radius": 11, "gpm": 2.00, "precip_sq": 1.59, "precip_tri": 1.84},
+                "25PSI": {"radius": 12, "gpm": 2.20, "precip_sq": 1.60, "precip_tri": 1.85},
+                "30PSI": {"radius": 12, "gpm": 2.52, "precip_sq": 1.68, "precip_tri": 1.95},
+                "35PSI": {"radius": 13, "gpm": 2.92, "precip_sq": 1.80, "precip_tri": 2.08},
+                "40PSI": {"radius": 13, "gpm": 3.36, "precip_sq": 1.91, "precip_tri": 2.21}
+              }
+            }
+          }
+        }
+      },
+      "15A": {
+        "minRadius": 9,
+        "maxRadius": 11,
+        "minArc": 0,
+        "maxArc": 360,
+        "arcSettings": {"45": 45, "90": 90, "120": 120, "180": 180, "240": 240, "270": 270, "360": 360},
+        "model": {
+          "15A": {
+            "minRadius": 9,
+            "maxRadius": 11,
+            "minArc": 0,
+            "maxArc": 360,
+            "arcSettings": {"45": 45, "90": 90, "120": 120, "180": 180, "240": 240, "270": 270, "360": 360},
+            "color": "#000000",
+            "angles": {
+              "45": {
+                "20PSI": {"radius": 14, "gpm": 0.39, "precip_sq": 1.51, "precip_tri": 1.75},
+                "25PSI": {"radius": 15, "gpm": 0.43, "precip_sq": 1.57, "precip_tri": 1.82},
+                "30PSI": {"radius": 15, "gpm": 0.47, "precip_sq": 1.59, "precip_tri": 1.84},
+                "35PSI": {"radius": 16, "gpm": 0.52, "precip_sq": 1.55, "precip_tri": 1.79},
+                "40PSI": {"radius": 17, "gpm": 0.57, "precip_sq": 1.60, "precip_tri": 1.85}
+              },
+              "90": {
+                "20PSI": {"radius": 14, "gpm": 0.77, "precip_sq": 1.51, "precip_tri": 1.75},
+                "25PSI": {"radius": 15, "gpm": 0.86, "precip_sq": 1.57, "precip_tri": 1.82},
+                "30PSI": {"radius": 15, "gpm": 0.93, "precip_sq": 1.59, "precip_tri": 1.84},
+                "35PSI": {"radius": 16, "gpm": 1.03, "precip_sq": 1.55, "precip_tri": 1.79},
+                "40PSI": {"radius": 17, "gpm": 1.13, "precip_sq": 1.60, "precip_tri": 1.85}
+              },
+              "120": {
+                "20PSI": {"radius": 14, "gpm": 1.03, "precip_sq": 1.51, "precip_tri": 1.75},
+                "25PSI": {"radius": 15, "gpm": 1.15, "precip_sq": 1.57, "precip_tri": 1.82},
+                "30PSI": {"radius": 15, "gpm": 1.24, "precip_sq": 1.59, "precip_tri": 1.84},
+                "35PSI": {"radius": 16, "gpm": 1.37, "precip_sq": 1.55, "precip_tri": 1.79},
+                "40PSI": {"radius": 17, "gpm": 1.51, "precip_sq": 1.60, "precip_tri": 1.85}
+              },
+              "180": {
+                "20PSI": {"radius": 14, "gpm": 1.54, "precip_sq": 1.51, "precip_tri": 1.75},
+                "25PSI": {"radius": 15, "gpm": 1.72, "precip_sq": 1.57, "precip_tri": 1.82},
+                "30PSI": {"radius": 15, "gpm": 1.86, "precip_sq": 1.59, "precip_tri": 1.84},
+                "35PSI": {"radius": 16, "gpm": 2.06, "precip_sq": 1.55, "precip_tri": 1.79},
+                "40PSI": {"radius": 17, "gpm": 2.26, "precip_sq": 1.60, "precip_tri": 1.85}
+              },
+              "240": {
+                "20PSI": {"radius": 14, "gpm": 2.05, "precip_sq": 1.51, "precip_tri": 1.75},
+                "25PSI": {"radius": 15, "gpm": 2.29, "precip_sq": 1.57, "precip_tri": 1.82},
+                "30PSI": {"radius": 15, "gpm": 2.48, "precip_sq": 1.59, "precip_tri": 1.84},
+                "35PSI": {"radius": 16, "gpm": 2.75, "precip_sq": 1.55, "precip_tri": 1.79},
+                "40PSI": {"radius": 17, "gpm": 3.01, "precip_sq": 1.60, "precip_tri": 1.85}
+              },
+              "270": {
+                "20PSI": {"radius": 14, "gpm": 2.31, "precip_sq": 1.51, "precip_tri": 1.75},
+                "25PSI": {"radius": 15, "gpm": 2.58, "precip_sq": 1.57, "precip_tri": 1.82},
+                "30PSI": {"radius": 15, "gpm": 2.79, "precip_sq": 1.59, "precip_tri": 1.84},
+                "35PSI": {"radius": 16, "gpm": 3.09, "precip_sq": 1.55, "precip_tri": 1.79},
+                "40PSI": {"radius": 17, "gpm": 3.39, "precip_sq": 1.60, "precip_tri": 1.85}
+              },
+              "360": {
+                "20PSI": {"radius": 14, "gpm": 3.08, "precip_sq": 1.51, "precip_tri": 1.75},
+                "25PSI": {"radius": 15, "gpm": 3.44, "precip_sq": 1.57, "precip_tri": 1.82},
+                "30PSI": {"radius": 15, "gpm": 3.72, "precip_sq": 1.59, "precip_tri": 1.84},
+                "35PSI": {"radius": 16, "gpm": 4.12, "precip_sq": 1.55, "precip_tri": 1.79},
+                "40PSI": {"radius": 17, "gpm": 4.52, "precip_sq": 1.60, "precip_tri": 1.85}
+              }
+            }
+          }
+        }
+      },
+      "17A": {
+        "minRadius": 9,
+        "maxRadius": 11,
+        "minArc": 0,
+        "maxArc": 360,
+        "arcSettings": {"45": 45, "90": 90, "120": 120, "180": 180, "240": 240, "270": 270, "360": 360},
+        "model": {
+          "17A": {
+            "minRadius": 9,
+            "maxRadius": 11,
+            "minArc": 0,
+            "maxArc": 360,
+            "arcSettings": {"45": 45, "90": 90, "120": 120, "180": 180, "240": 240, "270": 270, "360": 360},
+            "color": "#818080",
+            "angles": {
+              "45": {
+                "20PSI": {"radius": 16, "gpm": 0.49, "precip_sq": 1.46, "precip_tri": 1.68},
+                "25PSI": {"radius": 17, "gpm": 0.57, "precip_sq": 1.60, "precip_tri": 1.85},
+                "30PSI": {"radius": 17, "gpm": 0.58, "precip_sq": 1.53, "precip_tri": 1.77},
+                "35PSI": {"radius": 18, "gpm": 0.63, "precip_sq": 1.49, "precip_tri": 1.72},
+                "40PSI": {"radius": 19, "gpm": 0.69, "precip_sq": 1.55, "precip_tri": 1.79}
+              },
+              "90": {
+                "20PSI": {"radius": 16, "gpm": 0.97, "precip_sq": 1.46, "precip_tri": 1.68},
+                "25PSI": {"radius": 17, "gpm": 1.13, "precip_sq": 1.60, "precip_tri": 1.85},
+                "30PSI": {"radius": 17, "gpm": 1.15, "precip_sq": 1.53, "precip_tri": 1.77},
+                "35PSI": {"radius": 18, "gpm": 1.25, "precip_sq": 1.49, "precip_tri": 1.72},
+                "40PSI": {"radius": 19, "gpm": 1.38, "precip_sq": 1.55, "precip_tri": 1.79}
+              },
+              "120": {
+                "20PSI": {"radius": 16, "gpm": 1.29, "precip_sq": 1.46, "precip_tri": 1.68},
+                "25PSI": {"radius": 17, "gpm": 1.51, "precip_sq": 1.51, "precip_tri": 1.74},
+                "30PSI": {"radius": 17, "gpm": 1.53, "precip_sq": 1.53, "precip_tri": 1.77},
+                "35PSI": {"radius": 18, "gpm": 1.67, "precip_sq": 1.49, "precip_tri": 1.72},
+                "40PSI": {"radius": 19, "gpm": 1.84, "precip_sq": 1.47, "precip_tri": 1.70}
+              },
+              "180": {
+                "20PSI": {"radius": 16, "gpm": 1.94, "precip_sq": 1.46, "precip_tri": 1.68},
+                "25PSI": {"radius": 17, "gpm": 2.26, "precip_sq": 1.51, "precip_tri": 1.74},
+                "30PSI": {"radius": 17, "gpm": 2.30, "precip_sq": 1.53, "precip_tri": 1.77},
+                "35PSI": {"radius": 18, "gpm": 2.50, "precip_sq": 1.49, "precip_tri": 1.72},
+                "40PSI": {"radius": 19, "gpm": 2.76, "precip_sq": 1.47, "precip_tri": 1.70}
+              },
+              "240": {
+                "20PSI": {"radius": 16, "gpm": 2.59, "precip_sq": 1.46, "precip_tri": 1.68},
+                "25PSI": {"radius": 17, "gpm": 3.01, "precip_sq": 1.51, "precip_tri": 1.74},
+                "30PSI": {"radius": 17, "gpm": 3.07, "precip_sq": 1.53, "precip_tri": 1.77},
+                "35PSI": {"radius": 18, "gpm": 3.33, "precip_sq": 1.49, "precip_tri": 1.72},
+                "40PSI": {"radius": 19, "gpm": 3.68, "precip_sq": 1.47, "precip_tri": 1.70}
+              },
+              "270": {
+                "20PSI": {"radius": 16, "gpm": 2.91, "precip_sq": 1.46, "precip_tri": 1.68},
+                "25PSI": {"radius": 17, "gpm": 3.39, "precip_sq": 1.51, "precip_tri": 1.74},
+                "30PSI": {"radius": 17, "gpm": 3.45, "precip_sq": 1.53, "precip_tri": 1.77},
+                "35PSI": {"radius": 18, "gpm": 3.75, "precip_sq": 1.49, "precip_tri": 1.72},
+                "40PSI": {"radius": 19, "gpm": 4.14, "precip_sq": 1.47, "precip_tri": 1.70}
+              },
+              "360": {
+                "20PSI": {"radius": 16, "gpm": 3.88, "precip_sq": 1.46, "precip_tri": 1.68},
+                "25PSI": {"radius": 17, "gpm": 4.52, "precip_sq": 1.51, "precip_tri": 1.74},
+                "30PSI": {"radius": 17, "gpm": 4.60, "precip_sq": 1.53, "precip_tri": 1.77},
+                "35PSI": {"radius": 18, "gpm": 5.00, "precip_sq": 1.49, "precip_tri": 1.72},
+                "40PSI": {"radius": 19, "gpm": 5.52, "precip_sq": 1.47, "precip_tri": 1.70}
+              }
+            }
+          }
+        }
+      }
+    }
   }
 }

--- a/src/util/product.ts
+++ b/src/util/product.ts
@@ -255,7 +255,6 @@ export class Product extends Circle {
         if (nozzles[nozzle].minScaling > minScaling){
           minScaling = nozzles[nozzle].minScaling;
         }
-        // console.log(nozzles[nozzle].minScaling || 0.25)
         this.nozzleOptions[key] = {
           show: false,
           model: model,
@@ -293,7 +292,6 @@ export class Product extends Circle {
       }
     }
     this.water.setMinScaling(minScaling);
-    // console.log(this.nozzleOptions)
   }
 
   /**
@@ -328,9 +326,7 @@ export class Product extends Circle {
         const radius = data.angles[currAngle][prefPressure].radius;
 
         // Check if targetRadius is within the range of the current nozzle
-        // console.log(this.nozzleOptions[key])
         const roundedMinRadius = parseInt((radius*(1-this.nozzleOptions[key].minScaling)).toFixed(2));
-        // console.log(this.nozzleOptions[key].minScaling, roundedMinRadius)
         if (targetRadius >= roundedMinRadius &&
             targetRadius <= radius) {
           if(this.selectedNozzle !== key){
@@ -443,8 +439,6 @@ export class Product extends Circle {
     else if(!Object.keys(angleOptions).includes(model)){
       model = this.roundAngle(Object.keys(angleOptions))
     }
-
-    // console.log(angleOptions, model, pressure)
 
     // Check if the current radius is within the selected 
     // nozzle at pressure's radius

--- a/src/util/product.ts
+++ b/src/util/product.ts
@@ -255,6 +255,7 @@ export class Product extends Circle {
         if (nozzles[nozzle].minScaling > minScaling){
           minScaling = nozzles[nozzle].minScaling;
         }
+        // console.log(nozzles[nozzle].minScaling || 0.25)
         this.nozzleOptions[key] = {
           show: false,
           model: model,
@@ -292,6 +293,7 @@ export class Product extends Circle {
       }
     }
     this.water.setMinScaling(minScaling);
+    // console.log(this.nozzleOptions)
   }
 
   /**
@@ -326,7 +328,9 @@ export class Product extends Circle {
         const radius = data.angles[currAngle][prefPressure].radius;
 
         // Check if targetRadius is within the range of the current nozzle
+        // console.log(this.nozzleOptions[key])
         const roundedMinRadius = parseInt((radius*(1-this.nozzleOptions[key].minScaling)).toFixed(2));
+        // console.log(this.nozzleOptions[key].minScaling, roundedMinRadius)
         if (targetRadius >= roundedMinRadius &&
             targetRadius <= radius) {
           if(this.selectedNozzle !== key){
@@ -383,8 +387,6 @@ export class Product extends Circle {
       }
     }
 
-
-
     let selected = null;
     if(!this.selectedNozzle){
       for(let n in this.nozzleOptions){
@@ -438,6 +440,11 @@ export class Product extends Circle {
     if (Object.keys(angleOptions).length === 1){
       model = Object.keys(angleOptions)[0];
     }
+    else if(!Object.keys(angleOptions).includes(model)){
+      model = this.roundAngle(Object.keys(angleOptions))
+    }
+
+    // console.log(angleOptions, model, pressure)
 
     // Check if the current radius is within the selected 
     // nozzle at pressure's radius
@@ -515,12 +522,17 @@ export class Product extends Circle {
     return closestAngle;
   }
 
-  setNozzle(e: string){ 
-    if(!e){
+  /**
+   * Sets nozzle
+   * @param selectedNozzle 
+   * @returns {null}
+   */
+  setNozzle(selectedNozzle: string): void{ 
+    if(!selectedNozzle){
       return;
     }
-    this.selectedNozzle = e;
-    let nozzle = this.nozzleOptions[e];
+    this.selectedNozzle = selectedNozzle;
+    let nozzle = this.nozzleOptions[selectedNozzle];
     
     let angles = nozzle.arcSettings;
     const key = this.roundAngle(Object.keys(angles));
@@ -530,7 +542,7 @@ export class Product extends Circle {
     const closestPressure = this.roundPressure(pressures);
 
     // Selecting and outputting nozzle information
-    this.selectedNozzle = e;
+    this.selectedNozzle = selectedNozzle;
     let gpm = nozzle.data.angles[key][closestPressure].gpm;
     let precip_sq = nozzle.data.angles[key][closestPressure].precip_sq;
     let precip_tri = nozzle.data.angles[key][closestPressure].precip_tri;
@@ -544,7 +556,11 @@ export class Product extends Circle {
     this.water.canvas.renderAll();
   }
 
-  getSelectedNozzle(){
+  /**
+   * Gets the currently selected nozzle
+   * @returns {string}
+   */
+  getSelectedNozzle(): string{
     return this.selectedNozzle;
   }
 }

--- a/src/util/product.ts
+++ b/src/util/product.ts
@@ -1,9 +1,9 @@
-import { Circle, FabricText, Gradient, type TOriginX, type TOriginY } from 'fabric';
+import { Circle, FabricText, type TOriginX, type TOriginY } from 'fabric';
 import { Water } from './water';
 import data from "./data.json";
 
 
-interface AngleDetails {
+export interface AngleDetails {
   radius: number;
   gpm: number;
   precip_sq: number;
@@ -11,13 +11,13 @@ interface AngleDetails {
   gph?: number;
 }
 
-interface Angles {
+export interface Angles {
   [angle: string]: {
     [pressure: string]: AngleDetails;
   };
 }
 
-interface NozzleModel {
+export interface NozzleModel {
   minArc: number;
   maxArc: number;
   minRadius: number;
@@ -27,18 +27,18 @@ interface NozzleModel {
   angles: Angles;
 }
 
-interface NozzleTypes {
+export interface NozzleTypes {
   [model: string]: NozzleModel;
 }
 
-interface Nozzles {
+export interface Nozzles {
   [type: string]: {
     minScaling: any;
     model: NozzleTypes;
   };
 }
 
-interface ProductType {
+export interface ProductType {
   name: string;
   fixedArc: boolean;
   minArc: number;
@@ -50,19 +50,19 @@ interface ProductType {
   nozzles: Nozzles;
 }
 
-interface Products {
+export interface Products {
   [productID: string]: ProductType;
 }
 
 
 /**
- * Creates a Product object which filters data and
+ * Creates a HunterProduct object which filters data and
  * allows users to customize the object's water radius
  * and arc angle
  * 
  * @extends Circle
  */
-export class Product extends Circle {
+export class HunterProduct extends Circle {
   text: FabricText;
   data: any;
   water: Water;
@@ -80,7 +80,7 @@ export class Product extends Circle {
   autoSelectable: any;
 
   /**
-   * Constructs the Product object and is using 
+   * Constructs the HunterProduct object and is using 
    * waterOptions to create a Water object to allow for
    * customization
    * 
@@ -191,13 +191,13 @@ export class Product extends Circle {
   }
 
   /**
-   * Renders the Product object
+   * Renders the HunterProduct object
    * @param ctx 
    * @returns 
    */
   render(ctx : CanvasRenderingContext2D): void{
     super.render(ctx);
-    if(this.name === "PGP Ultra"){
+    if(this.name !== "Standard MP Rotator"){
       return;
     }
     ctx.save();
@@ -340,9 +340,6 @@ export class Product extends Circle {
               this.nozzleOptions[key].show = true;
               this.nozzleOptions[key].inArc = true;
               this.nozzleOptions[key].inRadius = true;
-              if (!this.selectedNozzle && this.autoSelectable) {
-                this.setNozzle(key);
-              }
               if (data.maxArc >= maxArc){
                 maxArc = data.maxArc;
               }
@@ -410,8 +407,23 @@ export class Product extends Circle {
         }
       }
     }
-    else{
-      
+
+    if (!this.autoSelectable){
+      return;
+    }
+    // Final loop to select a nozzle
+    let nozzleChosen = false;
+    for(let nozzle in nozzles){
+      const models = nozzles[nozzle].model
+      for(let model in models){
+        const key = `${nozzle}, ${model}`;
+        if (this.nozzleOptions[key].show && !nozzleChosen){
+          this.setNozzle(key)
+          nozzleChosen = true;
+          break;
+        }
+        if (nozzleChosen) break;
+      }
     }
   }
 

--- a/src/util/water.ts
+++ b/src/util/water.ts
@@ -1,4 +1,5 @@
 import {Path, Circle, Canvas, util, Line, FabricText} from 'fabric'
+import { Controller } from './controller';
 /**
  * Water and water controls of a product
  * 
@@ -71,7 +72,7 @@ export class Water extends Path {
     this.endAngle = endAngle;
     this.centerX = product.getCenterPoint().x;
     this.centerY = product.getCenterPoint().y;
-    this.waterScale = waterScale;
+    this.waterScale = options.waterScale | waterScale;
     this.radius = radius * this.waterScale;
     this.distance = this.radius;
     this.canvas = canvas;
@@ -89,7 +90,7 @@ export class Water extends Path {
     
     // Add control circles
     const endControlXY = this.getPointOnCircumference(this.radius, util.degreesToRadians(endAngle));
-    this.endController = new Circle({
+    this.endController = new Controller({
       left: endControlXY.x + centerX,
       top: endControlXY.y + centerY,
       radius: 7,
@@ -104,7 +105,7 @@ export class Water extends Path {
     });
 
     const startControlXY = this.getPointOnCircumference(this.radius, util.degreesToRadians(startAngle));
-    this.startController = new Circle({
+    this.startController = new Controller({
       left: startControlXY.x + centerX,
       top: startControlXY.y + centerY,
       radius: 7,
@@ -121,7 +122,7 @@ export class Water extends Path {
     const midAngle = this.computeMidAngle(startAngle, endAngle);
     this.midAngle = util.radiansToDegrees(midAngle);
     const midControllerXY = this.getPointOnCircumference(this.radius, util.degreesToRadians(midAngle));
-    this.midController = new Circle({
+    this.midController = new Controller({
       left: midControllerXY.x + centerX,
       top: midControllerXY.y + centerY,
       radius: 7,
@@ -784,6 +785,10 @@ export class Water extends Path {
 
   setMinScaling(scale: number): void {
     this.minScaling = scale;
+  }
+
+  updateWaterScale(waterScale: number): void {
+    this.waterScale = waterScale;
   }
 }
 export default Water;


### PR DESCRIPTION
What's new
-
- Pro Fixed Nozzles data has been added to the database
- User can select the new nozzles added

Set Up
-
- Clone repo
- In your command line:
  - run npm install to install necessary packages
  - run npm run dev to run the project in your web browser

On your browser, go to localhost:5173 and you should see a page with input fields with a black line and text reading "5 feet" under it.

Testing
-
- Click to add a Pro Fixed Nozzle
  - At first, the user can go anywhere from 180° to 360°. After it snaps to an angle, this no longer happens. I need to implement custom angle on initialize instead of 270°.
- There should be 21 different nozzles to choose from
- Changing the arc angle should also change the data for any Pro Fixed nozzle
- On Nozzle 5, the user can't go to 120°
- On Nozzle 17, the user can't go to 120° and 360°
- When adding a PGP Ultra, the initial color is white because no nozzle is selected. When a nozzle is selected, it turns black
- Previous functionality should remain the same
  - Nozzles options change depending on the arc and radius
  - Nozzles become deselected if its arc or radius don't match the current water arc and radius
  - Clicking on a nozzle shows information based on the current water arc and radius

Bugs Fixed
-
- Rotating on max angle when the max angle was under 360° has been fixed
  - Rotating no longer happens and the moving controller 'sticks' to the max arc